### PR TITLE
Fix language detection in language combobox on settings page.

### DIFF
--- a/src/qmlsettingswrapper.cpp
+++ b/src/qmlsettingswrapper.cpp
@@ -2,9 +2,11 @@
 #include <QDebug>
 
 QMLSettingsWrapper::QMLSettingsWrapper(QString organisation, QString application, QObject *parent) :
-    QObject(parent)
+    QObject(parent),
+    settings(new QSettings(organisation, application, this))
 {
-    this->settings = new QSettings(organisation, application, this);
+    if (!settings->value("locale").toBool())
+        settings->setValue("locale", QLocale().name().mid(0, 2));
 }
 
 QVariant QMLSettingsWrapper::value(const QString &key){


### PR DESCRIPTION
BUG: If system language is different from English and has not been
selected manually, language combobox on settings window shows "English".
![screenshot-07-07-15-20-25-28](https://cloud.githubusercontent.com/assets/6236802/8552546/7a64e9c2-24e6-11e5-953b-e9e32793179f.png)


FIX:Automatically write system language name to settings on first start.